### PR TITLE
Support partially collapsed quotes

### DIFF
--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -59,14 +59,16 @@ var QuoteCollapse = {
     // we don't need a BODY.mailview qualifier here
     var stylecontent='\
 blockquote[type="cite"] {\n\
- background: url("chrome://quotecollapse/skin/twisty-clsd.png") no-repeat top left;\n\
+ background-image: url("chrome://quotecollapse/skin/twisty-clsd.png");\n\
+ background-repeat: no-repeat;\n\
+ background-position: top left;\n\
  height: 2.25ex;\n\
  padding-bottom: 0px ! important;\n\
  overflow: -moz-hidden-unscrollable;\n\
 }\n\
 \n\
 blockquote[type="cite"][qctoggled="true"] {\n\
- background: url("chrome://quotecollapse/skin/twisty-open.png") no-repeat top left;\n\
+ background-image: url("chrome://quotecollapse/skin/twisty-open.png");\n\
  height: auto;\n\
  overflow: visible;\n\
 }\n\

--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -62,14 +62,14 @@ blockquote[type="cite"] {\n\
  background-image: url("chrome://quotecollapse/skin/twisty-clsd.png");\n\
  background-repeat: no-repeat;\n\
  background-position: top left;\n\
- height: 2.25ex;\n\
+ max-height: 2.25ex;\n\
  padding-bottom: 0px ! important;\n\
  overflow: -moz-hidden-unscrollable;\n\
 }\n\
 \n\
 blockquote[type="cite"][qctoggled="true"] {\n\
  background-image: url("chrome://quotecollapse/skin/twisty-open.png");\n\
- height: auto;\n\
+ max-height: none;\n\
  overflow: visible;\n\
 }\n\
 ';

--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -82,11 +82,21 @@ blockquote[type="cite"][qctoggled="true"] {\n\
     return (node.getAttribute("qctoggled")=="true");
   },
 
-  _setState: function(node, state) {
+  _setState: function(node, state, bubble) {
     if(state)
       node.setAttribute("qctoggled","true");
     else
       node.setAttribute("qctoggled","false");
+
+    if(bubble) {
+      var currentParent = node.parentNode;
+      while(currentParent) {
+        if(currentParent.nodeName == 'BLOCKQUOTE')
+          QuoteCollapse._setState(currentParent, state);
+
+        currentParent = currentParent.parentNode;
+      }
+    }
   },
 
   _setSubTree: function(node, state) {
@@ -154,7 +164,7 @@ blockquote[type="cite"][qctoggled="true"] {\n\
       if(event.ctrlKey || event.metaKey)
         QuoteCollapse._setLevel(target, newstate);
       else
-        QuoteCollapse._setState(target, newstate);
+        QuoteCollapse._setState(target, newstate, newstate);
     return true;
   },
 

--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -166,7 +166,7 @@ blockquote[type="cite"]:not([qctoggled="true"]) blockquote[type="cite"] {\n\
 
 
 // react only to active spot (leave rest for copy etc.)
-    if( (event.pageX > target.offsetLeft+12) || (event.pageY > target.offsetTop+12) ) return true;
+    if(event.pageX > target.offsetLeft+12) return true;
     
     if(event.shiftKey)
       if(event.ctrlKey || event.metaKey)

--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -72,6 +72,12 @@ blockquote[type="cite"][qctoggled="true"] {\n\
  max-height: none;\n\
  overflow: visible;\n\
 }\n\
+\n\
+blockquote[type="cite"]:not([qctoggled="true"]) blockquote[type="cite"] {\n\
+ background-image: url("chrome://quotecollapse/skin/twisty-clsd.png");\n\
+ max-height: 2.25ex;\n\
+ overflow: -moz-hidden-unscrollable;\n\
+}\n\
 ';
     var styletext = document.createTextNode(stylecontent);
     StyleElement.appendChild(styletext);
@@ -79,7 +85,14 @@ blockquote[type="cite"][qctoggled="true"] {\n\
   },
 
   _getState: function(node) {
-    return (node.getAttribute("qctoggled")=="true");
+    let current = node;
+    while(current) {
+      if(current.nodeName == "BLOCKQUOTE" && current.getAttribute("qctoggled") != "true")
+        return false;
+
+      current = current.parentNode
+    }
+    return true;
   },
 
   _setState: function(node, state, bubble) {

--- a/www/customising.html
+++ b/www/customising.html
@@ -42,20 +42,28 @@ QuoteCollapse._setTree(messageDocument, newstate);
 <P>
 <CODE><PRE>
 blockquote[type="cite"] {
-  background: url("chrome://quotecollapse/skin/twisty-clsd.png") no-repeat top left;
-  height: 2ex;
+  background-image: url("chrome://quotecollapse/skin/twisty-clsd.png");
+  background-repeat: no-repeat;
+  background-position: top left;
+  max-height: 2.25ex;
   padding-bottom: 0px ! important;
   overflow: -moz-hidden-unscrollable;
 }
 
 blockquote[type="cite"][qctoggled="true"] {
-  background: url("chrome://quotecollapse/skin/twisty-open.png") no-repeat top left;
-  height: auto;
+  background-image: url("chrome://quotecollapse/skin/twisty-open.png");
+  max-height: none;
   overflow: visible;
 }
 </PRE></CODE>
 <P>Therefore, you can style everything through your userContent.css. You can edit this file by hand or using the 
 <a href="http://cdn.mozdev.org/chromedit/">ChromeEdit extension</a>. Note that you have to use the &quot;important&quot; flag to override the default settings. Note also the use of <CODE>BODY.mailview</CODE> which ensures that the style is applied when viewing mails only (not in the editor).
+
+<P id="height-compat">
+<EM>Note,</EM> up to QuoteCollapse v0.9 the default styles used CSS <CODE>height</CODE>
+property instead of <CODE>max-height</CODE>.  If you upgrade from that version you'll
+need to adjust old customizations like: <CODE>height: auto</CODE> &#8594; <CODE>max-height:
+none</CODE>, and replace other <CODE>height</CODE> usages for <CODE>max-height</CODE>.
 <BR>Examples:
 
 <UL>
@@ -66,7 +74,7 @@ BODY.mailview blockquote[type="cite"] {
   background-image: url("chrome://quotecollapse/skin/twisty-open.png") !important;
   background-repeat: no-repeat !important;
   background-position: top left !important;
-  height: auto !important;
+  max-height: none !important;
   overflow: visible !important;
 }
 
@@ -74,7 +82,7 @@ BODY.mailview blockquote[type="cite"][qctoggled="true"] {
   background-image: url("chrome://quotecollapse/skin/twisty-clsd.png") !important;
   background-repeat: no-repeat !important;
   background-position: top left !important;
-  height: 2ex !important;
+  max-height: 2ex !important;
   padding-bottom: 0px !important;
   overflow: -moz-hidden-unscrollable !important;
 } 
@@ -91,7 +99,7 @@ BODY.mailview blockquote[type="cite"][qctoggled="true"] {
 <LI> Minimize collapsed size to the height of the twisty:
  <CODE><PRE>
 BODY.mailview blockquote[type="cite"]:not([qctoggled="true"]) {
-  height: 9px !important;
+  max-height: 9px !important;
 }
  </PRE></CODE>
 </LI>
@@ -101,7 +109,7 @@ BODY.mailview blockquote[type="cite"]:not([qctoggled="true"]) {
 /* overwrite quotecollapse default */
 blockquote[type="cite"] {
   background-image: none !important;
-  height: auto !important;
+  max-height: none !important;
   overflow: visible !important;
 }
 
@@ -110,7 +118,7 @@ BODY.mailview blockquote[type="cite"] blockquote[type="cite"] {
   background-image: url("chrome://quotecollapse/skin/twisty-clsd.png") !important;
   background-repeat: no-repeat !important;
   background-position: top left !important;
-  height: 2ex !important;
+  max-height: 2ex !important;
   padding-bottom: 0px !important;
   overflow: -moz-hidden-unscrollable !important;
 }
@@ -119,7 +127,7 @@ BODY.mailview blockquote[type="cite"] blockquote[type="cite"][qctoggled="true"] 
   background-image: url("chrome://quotecollapse/skin/twisty-open.png") !important;
   background-repeat: no-repeat !important;
   background-position: top left !important;
-  height: auto !important;
+  max-height: none !important;
   overflow: visible !important;
 }
  </PRE></CODE>
@@ -130,7 +138,7 @@ BODY.mailview blockquote[type="cite"] blockquote[type="cite"][qctoggled="true"] 
 /* overwrite quotecollapse default for first quote */
 DIV > pre:first-child + blockquote[type="cite"] {
   background-image: none !important;
-  height: auto !important;
+  max-height: none !important;
   overflow: visible !important;
 }</PRE></CODE>
  This may need to be tweaked depending on quoting styles. E.g., add the same rule for blockquotes which are first childs instead of adjacent to a first child pre.
@@ -141,7 +149,7 @@ DIV > pre:first-child + blockquote[type="cite"] {
 /* overwrite quotecollapse default for first quote */
 blockquote[type="cite"] {
   background-image: none !important;
-  height: auto !important;
+  max-height: none !important;
   overflow: visible !important;
 }
 
@@ -150,7 +158,7 @@ BODY.mailview DIV > pre:first-child + blockquote[type="cite"] {
   background-image: url("chrome://quotecollapse/skin/twisty-clsd.png") !important;
   background-repeat: no-repeat !important;
   background-position: top left !important;
-  height: 2ex !important;
+  max-height: 2ex !important;
   padding-bottom: 0px !important;
   overflow: -moz-hidden-unscrollable !important;
 }
@@ -159,7 +167,7 @@ BODY.mailview DIV > pre:first-child + blockquote[type="cite"][qctoggled="true"] 
   background-image: url("chrome://quotecollapse/skin/twisty-open.png") !important;
   background-repeat: no-repeat !important;
   background-position: top left !important;
-  height: auto !important;
+  max-height: none !important;
   overflow: visible !important;
 }</PRE></CODE>
 The same remark as above applies. Also, if you want twisties inside of the first quote, add rules for level 1 and deeper (see the example on expanding 1st level).

--- a/www/customising.html
+++ b/www/customising.html
@@ -173,6 +173,20 @@ BODY.mailview DIV > pre:first-child + blockquote[type="cite"][qctoggled="true"] 
 The same remark as above applies. Also, if you want twisties inside of the first quote, add rules for level 1 and deeper (see the example on expanding 1st level).
 </LI>
 
+<LI> Partially collapse quotes:
+ <CODE><PRE>
+/* partially reveal first level collapsed quotes */
+BODY.mailview blockquote[type="cite"]:not([qctoggled="true"]) {
+  max-height: 6.5em !important;
+}
+
+/* always have nested collapsed quotes reveal just one line of text */
+BODY.mailview blockquote[type="cite"]:not([qctoggled="true"])
+              blockquote[type="cite"]:not([qctoggled="true"]) {
+  max-height: 2ex !important;
+}</PRE></CODE>
+</LI>
+
 <LI>
 Note that you can specify different defaults for mail and news (thanks to Stanimir Stamenkov for this remark):
  <CODE><PRE>


### PR DESCRIPTION
<sub>\[This is part of selected patches I've suggested over email some year and a half ago.\]</sub>

**Abstract**

It could be much more convenient to have some of the quoted content always expanded (5-10 lines) so it provides immediate context to the reader while still having excessive quoting collapsed for ease of finding current reply content.

**Implementation details**

Original/factory behavior is not changed, but the default style is changed to use `max-height` instead of fixed `height`.  This is backwards-incompatible with existing customizations which adjust the `height` property of quotes.  It would need to go in release notes (simple replace of `height: auto` with `max-height: none`, and `height` with `max-height` for the rest should suffice), and I'll adjust the [_"Customizing"_](http://mjg.github.io/QuoteCollapse/customising.html) examples once it gets approved for inclusion.

To achieve the suggested _partially collapsed quotes_ one may use the following style customization:

```css
/* Partially reveal first level collapsed quotes */
body.mailview blockquote[type="cite"]:not([qctoggled="true"]) {
  max-height: 6.6em !important; /* line-height ~ 1.2em; 5.5 x 1.2 = 6.6 */
}

/* Always have nested collapsed quotes reveal just one line of text */
body.mailview blockquote[type="cite"]:not([qctoggled="true"])
              blockquote[type="cite"]:not([qctoggled="true"]) {
  max-height: 1.2em !important; /* line-height ~ 1.2em */
}
```

I've identified the following behavioral changes (included) are necessary to fully support the _partially collapsed quotes_ style:

-   Expanding a nested collapsed quote should expand parent container quotes as well;
-   Always treat quotes nested in a collapsed quote as collapsed – both visually and toggle behavior.

**Basic usage scenario**

Initial partially collapsed state:

![quotes-1](https://user-images.githubusercontent.com/1247730/37163069-d7785750-22c4-11e8-82ee-6b00cd8a8af3.png)

_Toggling the first level quote partially reveals the nested quote, and a fully collapsed third-level one:_

![quotes-2](https://user-images.githubusercontent.com/1247730/37163168-0d7ecab4-22c5-11e8-8b14-d1dbd0918b39.png)

_Toggling the third-level quote fully expands it and the parent container quote as well:_

![quotes-3](https://user-images.githubusercontent.com/1247730/37163244-444bfea4-22c5-11e8-8503-09d4b4fb268a.png)
