### PR TITLE
Expose Expand()/Collapse() for convenient key-bindings

### DIFF
--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -218,21 +218,17 @@ blockquote[type="cite"][qctoggled="true"] {\n\
   },
 
   _getCollapseLevels: function getCollapseLevels(node, current = 0, levels = { min: -1, max: -1 }) {
-    if(node.localName == "blockquote") {
-      if(node.getAttribute("qctoggled") != "true") {
+    let nestedQuotes = QuoteCollapse._getQuoteRoots(node);
+    for(let nested of nestedQuotes) {
+      if(nested.getAttribute("qctoggled") == "true")
+        getCollapseLevels(nested, current + 1, levels);
+      else {
         levels.min = (levels.min < 0) ? current : Math.min(current, levels.min);
         levels.max = (levels.max < 0) ? current : Math.max(current, levels.max);
-        return levels;
       }
-      current += 1;
     }
 
-    let nestedQuotes = QuoteCollapse._getQuoteRoots(node);
-    for(let i = 0; i < nestedQuotes.length; i++) {
-      getCollapseLevels(nestedQuotes[i], current, levels);
-    }
-
-    if(node.localName == "blockquote" && nestedQuotes.length == 0) {
+    if(nestedQuotes.length == 0 && current > 0) {
       levels.min = (levels.min < 0) ? current : Math.min(current, levels.min);
       levels.max = (levels.max < 0) ? current : Math.max(current, levels.max);
     }

--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -201,6 +201,22 @@ blockquote[type="cite"][qctoggled="true"] {\n\
     return true;
   },
 
+  Expand: function expand(deepest) {
+    let messageDocument = QuoteCollapse._messagePane.contentDocument;
+    let levels = QuoteCollapse._getCollapseLevels(messageDocument.body);
+    let targetLevel = deepest ? levels.max : levels.min;
+    if (targetLevel >= 0)
+      QuoteCollapse._setSubTreeLevel(messageDocument.body, true, targetLevel);
+  },
+
+  Collapse: function collapse(topMost) {
+    let messageDocument = QuoteCollapse._messagePane.contentDocument;
+    let levels = QuoteCollapse._getCollapseLevels(messageDocument.body);
+    let targetLevel = topMost ? levels.min : levels.max;
+    if (targetLevel > 0)
+      QuoteCollapse._setSubTreeLevel(messageDocument.body, false, targetLevel - 1);
+  },
+
   _getCollapseLevels: function getCollapseLevels(node, current = 0, levels = { min: -1, max: -1 }) {
     if(node.localName == "blockquote") {
       if(node.getAttribute("qctoggled") != "true") {

--- a/src/chrome/content/quotecollapse/quotecollapse.js
+++ b/src/chrome/content/quotecollapse/quotecollapse.js
@@ -201,6 +201,28 @@ blockquote[type="cite"][qctoggled="true"] {\n\
     return true;
   },
 
+  _getCollapseLevels: function getCollapseLevels(node, current = 0, levels = { min: -1, max: -1 }) {
+    if(node.localName == "blockquote") {
+      if(node.getAttribute("qctoggled") != "true") {
+        levels.min = (levels.min < 0) ? current : Math.min(current, levels.min);
+        levels.max = (levels.max < 0) ? current : Math.max(current, levels.max);
+        return levels;
+      }
+      current += 1;
+    }
+
+    let nestedQuotes = QuoteCollapse._getQuoteRoots(node);
+    for(let i = 0; i < nestedQuotes.length; i++) {
+      getCollapseLevels(nestedQuotes[i], current, levels);
+    }
+
+    if(node.localName == "blockquote" && nestedQuotes.length == 0) {
+      levels.min = (levels.min < 0) ? current : Math.min(current, levels.min);
+      levels.max = (levels.max < 0) ? current : Math.max(current, levels.max);
+    }
+    return levels;
+  },
+
   _getQuoteRoots: function getQuoteRoots(node, result = []) {
     for(let childElement of node.children) {
       if(childElement.localName == "blockquote")

--- a/www/customising.html
+++ b/www/customising.html
@@ -40,6 +40,21 @@ QuoteCollapse._setTree(messageDocument, newstate);
 
 <P> In future versions of QuoteCollapse there will be a special utility function QuoteCollapse.Toggle() which accomplishes the same.
 
+<P><STRONG>Version 1.2</STRONG> introduces:
+<UL>
+<LI><CODE>QuoteCollapse.Expand();</CODE>
+  <P>Expands first (top-most) collapsed level available.</LI>
+<LI><CODE>QuoteCollapse.Expand(true);</CODE>
+  <P>Expands the deepest collapsed level available.</LI>
+<LI><CODE>QuoteCollapse.Collapse();</CODE>
+  <P>Collapses the deepest expanded level available.</LI>
+<LI><CODE>QuoteCollapse.Collapse(true);</CODE>
+  <P>Collapses the top-most expanded level available.</LI>
+</UL>
+<P>It is anticipated people will mostly use just <CODE>QuoteCollapse.Expand()</CODE>
+and <CODE>QuoteCollapse.Collapse()</CODE>.  One may optionally bind the <CODE>(true)</CODE>
+variants with additional modifier like <kbd>Shift</kbd>.
+
 <h5><a id="style" name="style">Style</a></h5>
 
 


### PR DESCRIPTION
Pretty much like the `Toggle()` mentioned on the [_Customising_](https://mjg.github.io/QuoteCollapse/customising.html) page, but expands/collapses one level at a time.  The functions optionally accept a boolean (`true`) flag indicating if the _deepest_ or the _top-most_ level should be used:

> -   `QuoteCollapse.Expand();`
>
>     Expands first (top-most) collapsed level available.
>
> -   `QuoteCollapse.Expand(true);`
>
>     Expands the deepest collapsed level available.
>
> -   `QuoteCollapse.Collapse();`
>
>     Collapses the deepest expanded level available.
>
> -   `QuoteCollapse.Collapse(true);`
>
>     Collapses the top-most expanded level available.

Thus said the two variants behave exactly the same if there's only a single quote branch.  One may choose to use only one of the behaviors, or have them all bound like:

| function | key-binding |
| --- | --- |
| `QuoteCollapse.Expand()` | <kbd>Ctrl+RightArrow</kbd> |
| `QuoteCollapse.Expand(true)` | <kbd>Ctrl+Shift+RightArrow</kbd> |
| `QuoteCollapse.Collapse()` | <kbd>Ctrl+LeftArrow</kbd> |
| `QuoteCollapse.Collapse(true)` | <kbd>Ctrl+Shift+LeftArrow</kbd> |

---

The terminology _deepest_ and _top-most_ could be confusing.  One may think the _top-most expanded level available_ would be just the top (first/zero) level, while I really mean the first available when scanning bottom to top:

<pre>
<kbd>-</kbd> (0)
 └─<kbd>-</kbd> (1)

<kbd>-</kbd> (0)
 └─<kbd>-</kbd> (1)
    └─<kbd>-</kbd> (2)
       └─<kbd>+</kbd> (3)
          ╚═<kbd>+</kbd> (4)
</pre>

In the given example the _top-most expanded level available_ would be `1` – the shorter branch.  Then the _deepest expanded level available_ is `2` – on the longer branch.  If it was just one of the branches both will be the same.  I'm really open for suggestions for better wording here.